### PR TITLE
feat: add paycheck interval toggle

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,7 @@ QBConfig.Money.DontAllowMinus = { 'cash', 'crypto' }                -- Money tha
 QBConfig.Money.MinusLimit = -5000                                    -- The maximum amount you can be negative 
 QBConfig.Money.PayCheckTimeOut = 10                                 -- The time in minutes that it will give the paycheck
 QBConfig.Money.PayCheckSociety = false                              -- If true paycheck will come from the society account that the player is employed at, requires qb-management
+QBConfig.Money.PayCheckInterval = true                              -- Toggle paycheck interval, set false to disable
 
 QBConfig.Player = {}
 QBConfig.Player.HungerRate = 4.2 -- Rate at which hunger goes down.

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -401,6 +401,7 @@ function QBCore.Functions.CreateVehicle(source, model, vehtype, coords, warp)
 end
 
 function PaycheckInterval()
+    if not QBCore.Config.Money.PayCheckInterval then return end
     if not next(QBCore.Players) then
         SetTimeout(QBCore.Config.Money.PayCheckTimeOut * (60 * 1000), PaycheckInterval) -- Prevent paychecks from stopping forever once 0 players
         return
@@ -417,15 +418,18 @@ function PaycheckInterval()
                         TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('error.company_too_poor'), 'error')
                     else
                         Player.Functions.AddMoney('bank', payment, 'paycheck')
+                        TriggerEvent('QBCore:Server:PlayerPaid', Player.PlayerData.source, Player.PlayerData.job.name, Player.PlayerData.job.grade.level, payment)
                         exports['qb-banking']:RemoveMoney(Player.PlayerData.job.name, payment, 'Employee Paycheck')
                         TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
                     end
                 else
                     Player.Functions.AddMoney('bank', payment, 'paycheck')
+                    TriggerEvent('QBCore:Server:PlayerPaid', Player.PlayerData.source, Player.PlayerData.job.name, Player.PlayerData.job.grade.level, payment)
                     TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
                 end
             else
                 Player.Functions.AddMoney('bank', payment, 'paycheck')
+                TriggerEvent('QBCore:Server:PlayerPaid', Player.PlayerData.source, Player.PlayerData.job.name, Player.PlayerData.job.grade.level, payment)
                 TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
             end
         end

--- a/server/player.lua
+++ b/server/player.lua
@@ -663,4 +663,6 @@ function QBCore.Player.CreateSerialNumber()
     return QBCore.Player.CreateSerialNumber()
 end
 
-PaycheckInterval() -- This starts the paycheck system
+if QBCore.Config.Money.PayCheckInterval then
+    PaycheckInterval() -- This starts the paycheck system
+end


### PR DESCRIPTION
## Summary
- add PayCheckInterval config option to disable paycheck system
- respect the toggle in server startup and interval function
- emit `QBCore:Server:PlayerPaid` when paychecks are distributed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8bb764e0832ea4b1486b6505298f