### PR TITLE
feat: expose runtime job updates

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -114,6 +114,7 @@ QBConfig.Server.WhitelistPermission = 'admin'           -- Permission that's abl
 QBConfig.Server.PVP = true                              -- Enable or disable pvp on the server (Ability to shoot other players)
 QBConfig.Server.Discord = ''                            -- Discord invite link
 QBConfig.Server.CheckDuplicateLicense = true            -- Check for duplicate rockstar license on join
+QBConfig.Server.UseJobsDatabase = false                 -- Load jobs from database instead of shared/jobs.lua
 QBConfig.Server.Permissions = { 'god', 'admin', 'mod' } -- Add as many groups as you want here after creating them in your server.cfg
 
 QBConfig.Commands = {}                                  -- Command Configuration

--- a/qbcore.sql
+++ b/qbcore.sql
@@ -42,3 +42,22 @@ CREATE TABLE IF NOT EXISTS `player_contacts` (
   PRIMARY KEY (`id`),
   KEY `citizenid` (`citizenid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
+
+CREATE TABLE IF NOT EXISTS `jobs` (
+  `name` varchar(50) NOT NULL,
+  `label` varchar(50) NOT NULL,
+  `type` varchar(50) DEFAULT NULL,
+  `default_duty` tinyint(1) NOT NULL DEFAULT 1,
+  `off_duty_pay` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`name`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `job_grades` (
+  `job_name` varchar(50) NOT NULL,
+  `grade` int(11) NOT NULL,
+  `name` varchar(50) NOT NULL,
+  `payment` int(11) NOT NULL,
+  `isboss` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`job_name`,`grade`),
+  FOREIGN KEY (`job_name`) REFERENCES `jobs`(`name`) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/server/events.lua
+++ b/server/events.lua
@@ -40,6 +40,14 @@ if readyFunction ~= nil then
         if result and result[1] then
             bansTableExists = true
         end
+
+        if QBCore.Config.Server.UseJobsDatabase then
+            local jobsTable = MySQL.query.await('SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = "jobs";', {DatabaseInfo.database})
+            local gradesTable = MySQL.query.await('SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = "job_grades";', {DatabaseInfo.database})
+            if jobsTable and jobsTable[1] and gradesTable and gradesTable[1] then
+                QBCore.Functions.LoadJobs()
+            end
+        end
     end)
 end
 


### PR DESCRIPTION
## Summary
- support adding, removing, and updating job definitions at runtime
- optionally persist job changes to `jobs` and `job_grades` tables when `UseJobsDatabase` is enabled

## Testing
- `luac -p server/exports.lua server/functions.lua server/events.lua config.lua` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ffa6ce0832ebea73342225145a0